### PR TITLE
Decouple cppgraphqlgen::graphqljson from gqlmapi

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -30,6 +30,11 @@
           "name": "BUILD_SHARED_LIBS",
           "value": "False",
           "type": "BOOL"
+        },
+        {
+          "name": "IMPLICIT_GRAPHQLJSON_DEPENDENCY",
+          "value": "False",
+          "type": "BOOL"
         }
       ]
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,16 +43,13 @@ target_include_directories(gqlmapiCommon PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(gqlmapiCommon PUBLIC
   mapistub
-  mapi_schema
-  cppgraphqlgen::graphqljson)
+  mapi_schema)
 
 # Build a separate gqlmapi library as either static or shared depending on BUILD_SHARED_LIBS.
 add_library(gqlmapi Service.cpp)
 target_link_libraries(gqlmapi
   PRIVATE $<BUILD_INTERFACE:gqlmapiCommon>
-  INTERFACE
-    cppgraphqlgen::graphqlservice
-    cppgraphqlgen::graphqljson)
+  INTERFACE cppgraphqlgen::graphqlservice)
 target_include_directories(gqlmapi PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../schema>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -68,11 +65,17 @@ if(BUILD_SHARED_LIBS)
       RelWithDebInfo)
 
   install(FILES
-    $<TARGET_FILE:cppgraphqlgen::graphqljson>
     $<TARGET_FILE:cppgraphqlgen::graphqlpeg>
     $<TARGET_FILE:cppgraphqlgen::graphqlresponse>
     $<TARGET_FILE:cppgraphqlgen::graphqlservice>
     TYPE BIN)
+
+  option(INSTALL_GRAPHQLJSON "Include graphqljson.dll when installing gqlmapi.dll" ON)
+
+  if(INSTALL_GRAPHQLJSON)
+    install(FILES $<TARGET_FILE:cppgraphqlgen::graphqljson>
+      TYPE BIN)
+  endif()
 else()
   install(TARGETS
       mapistub

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,13 @@ add_library(gqlmapi Service.cpp)
 target_link_libraries(gqlmapi
   PRIVATE $<BUILD_INTERFACE:gqlmapiCommon>
   INTERFACE cppgraphqlgen::graphqlservice)
+
+option(IMPLICIT_GRAPHQLJSON_DEPENDENCY "Make the gqlmapi library depend on cppgraphqlgen::graphqljson implicitly." ON)
+
+if(IMPLICIT_GRAPHQLJSON_DEPENDENCY)
+  target_link_libraries(gqlmapi INTERFACE cppgraphqlgen::graphqljson)
+endif()
+
 target_include_directories(gqlmapi PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../schema>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -70,11 +77,8 @@ if(BUILD_SHARED_LIBS)
     $<TARGET_FILE:cppgraphqlgen::graphqlservice>
     TYPE BIN)
 
-  option(INSTALL_GRAPHQLJSON "Include graphqljson.dll when installing gqlmapi.dll" ON)
-
-  if(INSTALL_GRAPHQLJSON)
-    install(FILES $<TARGET_FILE:cppgraphqlgen::graphqljson>
-      TYPE BIN)
+  if(IMPLICIT_GRAPHQLJSON_DEPENDENCY)
+    install(FILES $<TARGET_FILE:cppgraphqlgen::graphqljson> TYPE BIN)
   endif()
 else()
   install(TARGETS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,11 @@ find_package(GTest CONFIG REQUIRED)
 include(GoogleTest)
 
 add_library(testShared STATIC gmock_main.cpp MockObjects.cpp)
-target_link_libraries(testShared PUBLIC gqlmapiCommon GTest::gtest GTest::gmock)
+target_link_libraries(testShared PUBLIC
+  gqlmapiCommon
+  cppgraphqlgen::graphqljson
+  GTest::gtest
+  GTest::gmock)
 
 add_executable(schemaTest SchemaTest.cpp)
 target_link_libraries(schemaTest PRIVATE testShared)


### PR DESCRIPTION
Most, but not all consumers of `gqlmapi` will need `cppgraphqlgen::graphqljson`. This change allows consumers to opt-out of linking `cppgraphqlgen::graphqljson` by setting the `IMPLICIT_GRAPHQLJSON_DEPENDENCY` option to `OFF`.